### PR TITLE
Testing AWS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ __pycache__/
 # Scrapy stuff:
 .scrapy
 
-# PyBuilder
-.pybuilder/
-target/
+# Terraform
+**/.terraform/*
+*.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/aws_test/main.tf
+++ b/aws_test/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  profile = "fourthbrain"
+  region  = "us-west-2"
+}
+
+
+data "aws_ami" "amazon-linux-2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+
+resource "aws_instance" "kbchatter-t2microtest" {
+  ami                         = data.aws_ami.amazon-linux-2.id
+  instance_type               = "t2.micro"
+  key_name                    = "flaskDeployment1"
+  associate_public_ip_address = true
+  security_groups             = ["kbchatter"]
+  iam_instance_profile        = "EC2S3"
+  user_data                   = file("user_data.sh")
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size           = 32
+    volume_type           = "standard"
+  }
+
+  tags = {
+    application = "knowledge base chatter bot"
+  }
+}
+
+
+output "instance_public_dns" {
+  value = aws_instance.kbchatter-t2microtest.public_dns
+}

--- a/aws_test/user_data.sh
+++ b/aws_test/user_data.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Setting up instance..."
+echo "Installing docker..."
+sudo yum update -y
+sudo amazon-linux-extras install docker
+sudo yum install docker
+sudo service docker start
+sudo usermod -a -G docker ec2-user
+echo "Done!"


### PR DESCRIPTION
I tested that I'm able to spin up an EC2 instance with terraform. I'm adding this here as a reference.

`terraform init` (only needs to be run once)
```
(base) Russells-MacBook-Air:aws_test rrruss$ terraform init

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/aws...
- Installing hashicorp/aws v3.40.0...
- Installed hashicorp/aws v3.40.0 (self-signed, key ID 34365D9472D7468F)

Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://www.terraform.io/docs/cli/plugins/signing.html

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

`terraform apply` spins up the EC2 instance using the most recent version of the Amazon Linux 2 AMI. I previously added a key pair and created a security group from the AWS Console so I'm specifying those. Also, I looked up a suitable existing [IAM role](https://console.aws.amazon.com/iam/home?region=us-west-2#/roles) that would allow us to access S3 from this EC2 instance. These are all configured in `main.tf`.
```
(base) Russells-MacBook-Air:aws_test rrruss$ terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_instance.kbchatter-t2microtest will be created
  + resource "aws_instance" "kbchatter-t2microtest" {
      + ami                                  = "ami-0cf6f5c8a62fa5da6"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + iam_instance_profile                 = "EC2S3"
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "flaskDeployment1"
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = [
          + "kbchatter",
        ]
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "application" = "knowledge base chatter bot"
        }
      + tags_all                             = {
          + "application" = "knowledge base chatter bot"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "0eee25b80e56d278eaad34d9920a0d8dd09c4c9d"
      + vpc_security_group_ids               = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 32
          + volume_type           = "standard"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + instance_public_dns = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_instance.kbchatter-t2microtest: Creating...
aws_instance.kbchatter-t2microtest: Still creating... [10s elapsed]
aws_instance.kbchatter-t2microtest: Still creating... [20s elapsed]
aws_instance.kbchatter-t2microtest: Still creating... [30s elapsed]
aws_instance.kbchatter-t2microtest: Creation complete after 33s [id=i-0b0fcf5288c198d74]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

instance_public_dns = "ec2-34-216-1-94.us-west-2.compute.amazonaws.com"
```

`ssh` into the EC2 instance using the public DNS given in the output above and check that
- Docker was installed
- we're able to access s3
```
(base) Russells-MacBook-Air:aws_test rrruss$ ssh -i "~/.ssh/flaskDeployment1.pem" ec2-user@ec2-34-216-1-94.us-west-2.compute.amazonaws.com
The authenticity of host 'ec2-34-216-1-94.us-west-2.compute.amazonaws.com (34.216.1.94)' can't be established.
ECDSA key fingerprint is SHA256:gmmoLCY1bhnbmDRjjenR0x0SBjrV0vwKhC+bEukwgCs.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'ec2-34-216-1-94.us-west-2.compute.amazonaws.com,34.216.1.94' (ECDSA) to the list of known hosts.

       __|  __|_  )
       _|  (     /   Amazon Linux 2 AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-2/
[ec2-user@ip-172-31-27-158 ~]$ docker info
Client:
 Context:    default
 Debug Mode: false

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 0
 Server Version: 20.10.4
 Storage Driver: overlay2
  Backing Filesystem: xfs
  Supports d_type: true
  Native Overlay Diff: true
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 05f951a3781f4f2c1911b05e61c160e9c30eaa8e
 runc version: 12644e614e25b05da6fd08a38ffa0cfe1903fdec
 init version: de40ad0
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 4.14.231-173.361.amzn2.x86_64
 Operating System: Amazon Linux 2
 OSType: linux
 Architecture: x86_64
 CPUs: 1
 Total Memory: 983.3MiB
 Name: ip-172-31-27-158.us-west-2.compute.internal
 ID: TC5U:ZIX5:ODD3:LDBO:M5AE:63FC:MB5K:VCRY:RZA7:APW5:SOGX:RZRU
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false

WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled
[ec2-user@ip-172-31-27-158 ~]$ aws s3 ls
2021-04-29 03:36:22 sagemaker-studio-524akegsvld
2021-03-30 00:36:15 sagemaker-us-east-1-681261969843
2021-05-13 00:58:41 samsung-annotation-teams
[ec2-user@ip-172-31-27-158 ~]$ exit
logout
Connection to ec2-34-216-1-94.us-west-2.compute.amazonaws.com closed.
```

Finally, `terraform destroy` terminates the instance.
```
(base) Russells-MacBook-Air:aws_test rrruss$ terraform destroy

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_instance.kbchatter-t2microtest will be destroyed
  - resource "aws_instance" "kbchatter-t2microtest" {
      - ami                                  = "ami-0cf6f5c8a62fa5da6" -> null
      - arn                                  = "arn:aws:ec2:us-west-2:681261969843:instance/i-0b0fcf5288c198d74" -> null
      - associate_public_ip_address          = true -> null
      - availability_zone                    = "us-west-2b" -> null
      - cpu_core_count                       = 1 -> null
      - cpu_threads_per_core                 = 1 -> null
      - disable_api_termination              = false -> null
      - ebs_optimized                        = false -> null
      - get_password_data                    = false -> null
      - hibernation                          = false -> null
      - iam_instance_profile                 = "EC2S3" -> null
      - id                                   = "i-0b0fcf5288c198d74" -> null
      - instance_initiated_shutdown_behavior = "stop" -> null
      - instance_state                       = "running" -> null
      - instance_type                        = "t2.micro" -> null
      - ipv6_address_count                   = 0 -> null
      - ipv6_addresses                       = [] -> null
      - key_name                             = "flaskDeployment1" -> null
      - monitoring                           = false -> null
      - primary_network_interface_id         = "eni-0174161cfcd785b31" -> null
      - private_dns                          = "ip-172-31-27-158.us-west-2.compute.internal" -> null
      - private_ip                           = "172.31.27.158" -> null
      - public_dns                           = "ec2-34-216-1-94.us-west-2.compute.amazonaws.com" -> null
      - public_ip                            = "34.216.1.94" -> null
      - secondary_private_ips                = [] -> null
      - security_groups                      = [
          - "kbchatter",
        ] -> null
      - source_dest_check                    = true -> null
      - subnet_id                            = "subnet-f0e93488" -> null
      - tags                                 = {
          - "application" = "knowledge base chatter bot"
        } -> null
      - tags_all                             = {
          - "application" = "knowledge base chatter bot"
        } -> null
      - tenancy                              = "default" -> null
      - user_data                            = "0eee25b80e56d278eaad34d9920a0d8dd09c4c9d" -> null
      - vpc_security_group_ids               = [
          - "sg-0d8cb6d4b16d980b9",
        ] -> null

      - credit_specification {
          - cpu_credits = "standard" -> null
        }

      - enclave_options {
          - enabled = false -> null
        }

      - metadata_options {
          - http_endpoint               = "enabled" -> null
          - http_put_response_hop_limit = 1 -> null
          - http_tokens                 = "optional" -> null
        }

      - root_block_device {
          - delete_on_termination = true -> null
          - device_name           = "/dev/xvda" -> null
          - encrypted             = false -> null
          - iops                  = 0 -> null
          - throughput            = 0 -> null
          - volume_id             = "vol-0d96516c3db1678eb" -> null
          - volume_size           = 32 -> null
          - volume_type           = "standard" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - instance_public_dns = "ec2-34-216-1-94.us-west-2.compute.amazonaws.com" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

aws_instance.kbchatter-t2microtest: Destroying... [id=i-0b0fcf5288c198d74]
aws_instance.kbchatter-t2microtest: Still destroying... [id=i-0b0fcf5288c198d74, 10s elapsed]
aws_instance.kbchatter-t2microtest: Still destroying... [id=i-0b0fcf5288c198d74, 20s elapsed]
aws_instance.kbchatter-t2microtest: Still destroying... [id=i-0b0fcf5288c198d74, 30s elapsed]
aws_instance.kbchatter-t2microtest: Still destroying... [id=i-0b0fcf5288c198d74, 40s elapsed]
aws_instance.kbchatter-t2microtest: Destruction complete after 41s

Destroy complete! Resources: 1 destroyed.
```

Note that in `main.tf`, I'm specifying the AWS profile `fourthbrain` which is configured on my machine to use our Fourthbrain credentials.